### PR TITLE
initial implementation of SKI package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 ehthumbs.db
 Thumbs.db
 
+# glide cruft #
+###############
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+MAKEFLAGS += --warn-undefined-variables
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -euc
+.DEFAULT_GOAL := build
+GOPATH := $(abspath $(shell pwd)/../../../..)
+
+help:
+	@echo -e "\033[32m"
+	@echo "This project uses glide to manage its dependencies. Download the"
+	@echo "latest version from https://github.com/Masterminds/glide/releases"
+	@echo "Targets in this Makefile will set the GOPATH appropriately if the"
+	@echo "repository is within ./src/github.com/plan-tools/go-plan"
+	@echo "Otherwise... good luck."
+	@echo "GOPATH=$(GOPATH)"
+
+# ----------------------------------------
+# working environment
+
+GLIDE_ERR := "You need glide installed to set up this project. Download the latest version from https://github.com/Masterminds/glide/releases"
+check-glide:
+	@command -v glide || { echo $(GLIDE_ERR) ; exit 1;}
+
+setup: check-glide glide.lock
+
+glide.lock: glide.yaml
+	mkdir -p vendor
+	GOPATH=$(GOPATH) glide up
+
+build: build/ski build/pnode glide.lock
+
+build/ski:
+	GOPATH=$(GOPATH) go build -o ski ./cmd/ski/main.go
+
+build/pnode:
+	GOPATH=$(GOPATH) go build -o pnode ./cmd/pnode/main.go
+
+
+# ----------------------------------------
+# demo
+
+run:
+	GOPATH=$(GOPATH) go run main.go
+
+# set a single package to test by passing the PKG variable
+PKG ?=
+ifeq ($(PKG), )
+PKG := ./...
+else
+PKG := github.com/plan-tools/go-plan/$(PKG)
+endif
+
+test:
+	GOPATH=$(GOPATH) go test -v $(PKG)

--- a/cmd/pnode/main.go
+++ b/cmd/pnode/main.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/ski/main.go
+++ b/cmd/ski/main.go
@@ -1,0 +1,1 @@
+package main

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,24 @@
+hash: 1553a4fde7da0d73f7c820cdf8a3322041ab15ed8719d507470ffb7b84341cc5
+updated: 2018-08-13T15:11:37.820640855-04:00
+imports:
+- name: github.com/ethereum/go-ethereum
+  version: e07e507d1af687cd64b263038ebd3cb7be74fb40
+  subpackages:
+  - common/hexutil
+  - crypto/sha3
+  - rlp
+- name: github.com/mattn/go-sqlite3
+  version: b3511bfdd742af558b54eb6160aca9446d762a19
+- name: golang.org/x/crypto
+  version: de0752318171da717af4ce24d0a2e8626afaeb11
+  subpackages:
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
+  - internal/subtle
+  - nacl/box
+  - nacl/secretbox
+  - nacl/sign
+  - poly1305
+  - salsa20/salsa
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,9 @@
+package: github.com/plan-tools/go-plan
+import:
+- package: github.com/ethereum/go-ethereum/common/hexutil
+- package: github.com/ethereum/go-ethereum/crypto/sha3
+- package: github.com/ethereum/go-ethereum/rlp
+- package: github.com/mattn/go-sqlite3
+- package: golang.org/x/crypto/nacl/box
+- package: golang.org/x/crypto/nacl/secretbox
+- package: golang.org/x/crypto/nacl/sign

--- a/ski/README.md
+++ b/ski/README.md
@@ -1,0 +1,137 @@
+# ski
+--
+    import "github.com/plan-tools/go-plan/ski"
+
+Package ski is a reference implementation of the SKI plugin
+
+## Usage
+
+#### type SKI
+
+```go
+type SKI struct {
+}
+```
+
+SKI represents the external SKI process and holds the keyring.
+
+#### func  NewSKI
+
+```go
+func NewSKI() *SKI
+```
+NewSKI initializes the SKI's keying.
+
+#### func (*SKI) AcceptVouch
+
+```go
+func (ski *SKI) AcceptVouch(
+	recvPubKey plan.IdentityPublicKey,
+	bodyCrypt []byte,
+	senderPubKey plan.IdentityPublicKey,
+) error
+```
+AcceptVouch decrypts the encrypted buffer written by Vouch and decrypts it for
+the recipient.
+
+#### func (*SKI) Decrypt
+
+```go
+func (ski *SKI) Decrypt(
+	keyID plan.CommunityKeyID,
+	encrypted []byte,
+) ([]byte, error)
+```
+Decrypt takes an encrypted buffer and decrypts it using the community key and
+returns the cleartext buffer (or an error).
+
+#### func (*SKI) DecryptFrom
+
+```go
+func (ski *SKI) DecryptFrom(
+	recvPubKey plan.IdentityPublicKey,
+	encrypted []byte,
+	senderPubKey plan.IdentityPublicKey,
+) ([]byte, error)
+```
+DecryptFrom takes an encrypted buffer and a public key, and decrypts the message
+using the recipients private key. It returns the decrypted buffer (or an error).
+
+#### func (*SKI) Encrypt
+
+```go
+func (ski *SKI) Encrypt(keyId plan.CommunityKeyID, msg []byte,
+) ([]byte, error)
+```
+Encrypt accepts a buffer and encrypts it with the community key and returns the
+encrypted buffer (or an error). Typically the msg buffer will be a serialized
+PDIEntryBody or PDIEntryHeader. This is authenticated encryption but the caller
+will follow this call with a call to Verify the PDIEntryHash for validation.
+
+#### func (*SKI) EncryptFor
+
+```go
+func (ski *SKI) EncryptFor(
+	senderPubKey plan.IdentityPublicKey,
+	msg []byte,
+	recvPubKey plan.IdentityPublicKey,
+) ([]byte, error)
+```
+EncryptFor accepts a buffer and encrypts it for the public key of the intended
+recipient and returns the encrypted buffer. Typically the msg buffer will be a
+serialized PDIEntryBody or PDIEntryHeader. Note: this is how the Vouch operation
+works under the hood except that the Vouch caller doesn't know what goes in the
+message body. Outside of Vouch operations, this is the basis of private messages
+between users. The caller will follow this call with a call to Sign the
+PDIEntryHash
+
+#### func (*SKI) NewCommunityKey
+
+```go
+func (ski *SKI) NewCommunityKey() plan.CommunityKeyID
+```
+NewCommunityKey generates a new community key, adds it to the keyring, and
+returns the CommunityKeyID associated with that key.
+
+#### func (*SKI) NewIdentity
+
+```go
+func (ski *SKI) NewIdentity() (
+	plan.IdentityPublicKey, plan.IdentityPublicKey)
+```
+NewIdentity generates encryption and signing keys, adds them to the keyring, and
+returns the public keys associated with those private keys as (encryption,
+signing).
+
+#### func (*SKI) Sign
+
+```go
+func (ski *SKI) Sign(signer plan.IdentityPublicKey, hash plan.PDIEntryHash,
+) (plan.PDIEntrySig, error)
+```
+Sign accepts a message hash and returns a signature.
+
+#### func (*SKI) Verify
+
+```go
+func (ski *SKI) Verify(
+	pubKey plan.IdentityPublicKey,
+	hash plan.PDIEntryHash,
+	sig plan.PDIEntrySig,
+) ([]byte, bool)
+```
+Verify accepts a signature and verfies it against the public key of the sender.
+Returns the verified buffer (so it can be compared by the caller) and a bool
+indicating success.
+
+#### func (*SKI) Vouch
+
+```go
+func (ski *SKI) Vouch(
+	communityKeyID plan.CommunityKeyID,
+	senderPubKey plan.IdentityPublicKey,
+	recvPubKey plan.IdentityPublicKey,
+) ([]byte, error)
+```
+Vouch encrypts a CommunityKey for the recipients public encryption key, and
+returns the encrypted buffer (or error)

--- a/ski/keyring.go
+++ b/ski/keyring.go
@@ -1,0 +1,159 @@
+package ski // import "github.com/plan-tools/go-plan/ski"
+
+import (
+	crypto_rand "crypto/rand"
+	"sync"
+
+	plan "github.com/plan-tools/go-plan/plan"
+	box "golang.org/x/crypto/nacl/box"
+	sign "golang.org/x/crypto/nacl/sign"
+)
+
+// keyring represents the storage of keys
+type keyring struct {
+	communityKeys map[plan.CommunityKeyID]plan.CommunityKey
+	signingKeys   map[plan.IdentityPublicKey]*[64]byte
+	encryptKeys   map[plan.IdentityPublicKey]*[32]byte
+	mux           sync.RWMutex // synchronized changes to the keyring
+}
+
+func newKeyring() *keyring {
+	return &keyring{
+		communityKeys: map[plan.CommunityKeyID]plan.CommunityKey{},
+		signingKeys:   map[plan.IdentityPublicKey]*[64]byte{},
+		encryptKeys:   map[plan.IdentityPublicKey]*[32]byte{},
+	}
+}
+
+// ---------------------------------------------------------
+// self identity functions
+//
+
+// NewIdentity generates encryption and signing keys, adds them to the
+// keyring, and returns the public keys associated with those private
+// keys.
+func (kr *keyring) NewIdentity() (plan.IdentityPublicKey, plan.IdentityPublicKey) {
+
+	// generate new key material
+	encryptPubKey, encryptPrivateKey := generateEncryptionKey()
+	signingPubKey, signingPrivateKey := generateSigningKey()
+
+	// store it in the keyring and return the public keys
+	kr.mux.Lock()
+	defer kr.mux.Unlock()
+	kr.signingKeys[signingPubKey] = signingPrivateKey
+	kr.encryptKeys[encryptPubKey] = encryptPrivateKey
+	return encryptPubKey, signingPubKey
+}
+
+// GetSigningKey fetches the user's private signing key from the keychain for a
+// specific public key, or an error if the key doesn't exist.
+func (kr *keyring) GetSigningKey(pubKey plan.IdentityPublicKey) (
+	*[64]byte, error) {
+	var key *[64]byte
+	kr.mux.RLock()
+	defer kr.mux.RUnlock()
+	key, ok := kr.signingKeys[pubKey]
+	if !ok {
+		return key, plan.Errorf(-1,
+			"GetSigningKey: signing key %v does not exist", pubKey)
+	}
+	return key, nil
+}
+
+// GetEncryptKey fetches the user's private encrypt key from the keychain,
+// or an error if the key doesn't exist.
+func (kr *keyring) GetEncryptKey(pubKey plan.IdentityPublicKey) (
+	*[32]byte, error) {
+	var key *[32]byte
+	kr.mux.RLock()
+	defer kr.mux.RUnlock()
+	key, ok := kr.encryptKeys[pubKey]
+	if !ok {
+		return key, plan.Errorf(-1,
+			"GetEncryptKey: encrypt key %v does not exist", pubKey)
+	}
+	return key, nil
+}
+
+// Removes any instance of a key associated with the public key provided
+// from the keyring
+func (kr *keyring) InvalidateIdentity(key plan.IdentityPublicKey) {
+	kr.mux.Lock()
+	defer kr.mux.Unlock()
+	delete(kr.signingKeys, key)
+	delete(kr.encryptKeys, key)
+}
+
+func generateEncryptionKey() (plan.IdentityPublicKey, *[32]byte) {
+	publicKey, privateKey, err := box.GenerateKey(crypto_rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	return newPubKey(publicKey), privateKey
+}
+
+func generateSigningKey() (plan.IdentityPublicKey, *[64]byte) {
+	publicKey, privateKey, err := sign.GenerateKey(crypto_rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	return newPubKey(publicKey), privateKey
+}
+
+// ---------------------------------------------------------
+// community key functions
+//
+
+// NewCommunityKey generates a new community key, adds it to the keyring,
+// and returns the CommunityKeyID associated with that key.
+func (kr *keyring) NewCommunityKey() plan.CommunityKeyID {
+	kr.mux.Lock()
+	defer kr.mux.Unlock()
+	key, keyId := generateSymmetricKey()
+	kr.communityKeys[keyId] = key
+	return keyId
+}
+
+// InstallCommunityKey adds a new community key to the keychain
+func (kr *keyring) InstallCommunityKey(
+	keyId plan.CommunityKeyID, key plan.CommunityKey) {
+	kr.mux.Lock()
+	defer kr.mux.Unlock()
+	kr.communityKeys[keyId] = key
+}
+
+// GetCommunityKeyByID fetches the community key from the keychain for a
+// based on its ID, or an error if the key doesn't exist.
+func (kr *keyring) GetCommunityKeyByID(keyId plan.CommunityKeyID) (
+	plan.CommunityKey, error) {
+	var key plan.CommunityKey
+	kr.mux.RLock()
+	defer kr.mux.RUnlock()
+	key, ok := kr.communityKeys[keyId]
+	if !ok {
+		return key, plan.Errorf(-1,
+			"GetCommunityKeyByID: community key %v does not exist", keyId)
+	}
+	return key, nil
+}
+
+func generateSymmetricKey() ([32]byte, plan.CommunityKeyID) {
+	secret := make([]byte, 32)
+	_, err := crypto_rand.Read(secret)
+	if err != nil {
+		panic(err) // TODO: unclear when we'd ever hit this?
+	}
+	var key [32]byte
+	copy(key[:32], secret[:])
+
+	keyId := make([]byte, 16) // TODO: is this enough for uniqueness?
+	_, err = crypto_rand.Read(keyId)
+	if err != nil {
+		panic(err) // TODO: unclear when we'd ever hit this?
+	}
+	var communityId plan.CommunityKeyID
+	copy(communityId[:16], keyId[:])
+
+	return key, communityId
+}

--- a/ski/salt.go
+++ b/ski/salt.go
@@ -1,0 +1,33 @@
+package ski // import "github.com/plan-tools/go-plan/ski"
+
+import (
+	crypto_rand "crypto/rand"
+)
+
+var salts = saltGenerator()
+
+type salt [24]byte
+
+// needed by the SKI to cast our typedef
+func saltToArray(n salt) *[24]byte {
+	var arr [24]byte
+	copy(n[:], arr[:24])
+	return &arr
+}
+
+func saltGenerator() <-chan [24]byte {
+	saltChan := make(chan [24]byte) // note: *must* be a blocking chan!
+	go func() {
+		for {
+			currentSalt := make([]byte, 24)
+			_, err := crypto_rand.Read(currentSalt)
+			if err != nil {
+				panic(err) // TODO: unclear when we'd ever hit this?
+			}
+			var salt salt
+			copy(salt[:24], currentSalt[:])
+			saltChan <- salt
+		}
+	}()
+	return saltChan
+}

--- a/ski/ski.go
+++ b/ski/ski.go
@@ -1,0 +1,261 @@
+// Package ski is a reference implementation of the SKI plugin
+package ski // import "github.com/plan-tools/go-plan/ski"
+
+import (
+	"encoding/json"
+
+	plan "github.com/plan-tools/go-plan/plan"
+	box "golang.org/x/crypto/nacl/box"
+	secretbox "golang.org/x/crypto/nacl/secretbox"
+	sign "golang.org/x/crypto/nacl/sign"
+)
+
+// SKI represents the external SKI process and holds the keyring.
+type SKI struct {
+	keyring *keyring
+}
+
+// NewSKI initializes the SKI's keying.
+func NewSKI() *SKI {
+	ski := &SKI{keyring: newKeyring()}
+	return ski
+}
+
+// ---------------------------------------------------------
+//
+// Top-level functions of the SKI. Because these APIs are intended to
+// stand-in for the ones we'll have used across process boundaries, they
+// are designed to minimize the amount of serialization and wire traffic
+// required, and reduce the knowledge the SKI has about what's being done
+// with these values.
+
+// Vouch encrypts a CommunityKey for the recipients public encryption key,
+// and returns the encrypted buffer (or error)
+func (ski *SKI) Vouch(
+	communityKeyID plan.CommunityKeyID,
+	senderPubKey plan.IdentityPublicKey,
+	recvPubKey plan.IdentityPublicKey,
+) ([]byte, error) {
+	communityKey, err := ski.keyring.GetCommunityKeyByID(communityKeyID)
+	if err != nil {
+		return []byte{}, err
+	}
+	keyMsgBody := vouchMessage{KeyID: communityKeyID, Key: communityKey}
+	serializedBody, err := json.Marshal(keyMsgBody)
+	if err != nil {
+		return []byte{}, err
+	}
+	pdiMsgBody := &plan.PDIEntryBody{
+		BodyParts: []plan.PDIBodyPart{
+			plan.PDIBodyPart{
+				// TODO: presumably we want some kind of codec here
+				Header: "/plan/key",
+				Body:   serializedBody,
+			},
+		},
+	}
+	// TODO: is there a 2nd codec here we need to somehow specify?
+	msg, err := json.Marshal(pdiMsgBody)
+	if err != nil {
+		return []byte{}, err
+	}
+	return ski.EncryptFor(senderPubKey, msg, recvPubKey)
+}
+
+// AcceptVouch decrypts the encrypted buffer written by Vouch and decrypts
+// it for the recipient.
+func (ski *SKI) AcceptVouch(
+	recvPubKey plan.IdentityPublicKey,
+	bodyCrypt []byte,
+	senderPubKey plan.IdentityPublicKey,
+) error {
+	msg, err := ski.DecryptFrom(recvPubKey, bodyCrypt, senderPubKey)
+	if err != nil {
+		return err
+	}
+	pdiMsgBody := &plan.PDIEntryBody{}
+	err = json.Unmarshal(msg, pdiMsgBody)
+	if err != nil {
+		return err
+	}
+	keyMsgBody := &vouchMessage{}
+	err = json.Unmarshal(pdiMsgBody.BodyParts[0].Body, keyMsgBody)
+	if err != nil {
+		return err
+	}
+	ski.keyring.InstallCommunityKey(keyMsgBody.KeyID, keyMsgBody.Key)
+	return nil
+}
+
+// internal: the message sent by the Vouch process
+type vouchMessage struct {
+	KeyID plan.CommunityKeyID
+	Key   plan.CommunityKey
+}
+
+// Sign accepts a message hash and returns a signature.
+func (ski *SKI) Sign(signer plan.IdentityPublicKey, hash plan.PDIEntryHash,
+) (plan.PDIEntrySig, error) {
+	privateKey, err := ski.keyring.GetSigningKey(signer)
+	if err != nil {
+		return plan.PDIEntrySig{}, err
+	}
+	signed := sign.Sign([]byte{}, hash[:], privateKey)
+	return newSig(signed[:64]), nil
+}
+
+// Encrypt accepts a buffer and encrypts it with the community key and returns
+// the encrypted buffer (or an error). Typically the msg buffer will be a
+// serialized PDIEntryBody or PDIEntryHeader. This is authenticated encryption
+// but the caller will follow this call with a call to Verify the PDIEntryHash
+// for validation.
+func (ski *SKI) Encrypt(keyId plan.CommunityKeyID, msg []byte,
+) ([]byte, error) {
+	salt := <-salts
+	communityKey, err := ski.keyring.GetCommunityKeyByID(keyId)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	encrypted := secretbox.Seal(salt[:], msg,
+		&salt, communityKeyToArray(communityKey))
+	return encrypted, nil
+}
+
+// EncryptFor accepts a buffer and encrypts it for the public key of the
+// intended recipient and returns the encrypted buffer. Typically the msg
+// buffer will be a serialized PDIEntryBody or PDIEntryHeader. Note: this
+// is how the Vouch operation works under the hood except that the Vouch
+// caller doesn't know what goes in the message body. Outside of Vouch
+// operations, this is the basis of private messages between users. The
+// caller will follow this call with a call to Sign the PDIEntryHash
+func (ski *SKI) EncryptFor(
+	senderPubKey plan.IdentityPublicKey,
+	msg []byte,
+	recvPubKey plan.IdentityPublicKey,
+) ([]byte, error) {
+	salt := <-salts
+	privateKey, err := ski.keyring.GetEncryptKey(senderPubKey)
+	if err != nil {
+		return []byte{}, err
+	}
+	encrypted := box.Seal(salt[:], msg,
+		&salt, pubKeyToArray(recvPubKey), privateKey)
+	return encrypted, nil
+}
+
+// Verify accepts a signature and verfies it against the public key of the
+// sender. Returns the verified buffer (so it can be compared by the caller)
+// and a bool indicating success.
+func (ski *SKI) Verify(
+	pubKey plan.IdentityPublicKey,
+	hash plan.PDIEntryHash,
+	sig plan.PDIEntrySig,
+) ([]byte, bool) {
+	// TODO: this probably doesn't need to be in the SKI because it doesn't
+	//       require any private key material?
+
+	// need to re-combine the sig and hash to produce the
+	// signed message that Open expects
+	var signedMsg []byte
+	signedMsg = append(signedMsg, sig[:]...)
+	signedMsg = append(signedMsg, hash[:]...)
+	verified, ok := sign.Open([]byte{}, signedMsg[:], pubKeyToArray(pubKey))
+	return verified, ok
+}
+
+// Decrypt takes an encrypted buffer and decrypts it using the community key
+// and returns the cleartext buffer (or an error).
+func (ski *SKI) Decrypt(
+	keyID plan.CommunityKeyID,
+	encrypted []byte,
+) ([]byte, error) {
+	communityKey, err := ski.keyring.GetCommunityKeyByID(keyID)
+	if err != nil {
+		return []byte{}, err
+	}
+	var salt [24]byte
+	copy(salt[:], encrypted[:24])
+	decrypted, ok := secretbox.Open(nil, encrypted[24:],
+		&salt, communityKeyToArray(communityKey))
+	if !ok {
+		return nil, plan.Error(
+			-1, "secretbox.Open failed but doesn't produce an error")
+	}
+	return decrypted, nil
+}
+
+// DecryptFrom takes an encrypted buffer and a public key, and decrypts the
+// message using the recipients private key. It returns the decrypted buffer
+// (or an error).
+func (ski *SKI) DecryptFrom(
+	recvPubKey plan.IdentityPublicKey,
+	encrypted []byte,
+	senderPubKey plan.IdentityPublicKey,
+) ([]byte, error) {
+	privateKey, err := ski.keyring.GetEncryptKey(recvPubKey)
+	if err != nil {
+		return []byte{}, err
+	}
+	var salt [24]byte
+	copy(salt[:], encrypted[:24])
+	decrypted, ok := box.Open(nil, encrypted[24:],
+		&salt, pubKeyToArray(senderPubKey), privateKey)
+	if !ok {
+		return nil, plan.Error(
+			-1, "box.Open failed but doesn't produce an error")
+	}
+	return decrypted, nil
+}
+
+// ---------------------------------------------------------
+// Key and identity management functions
+// These mostly wrap the underlying keying.
+
+// NewIdentity generates encryption and signing keys, adds them to the
+// keyring, and returns the public keys associated with those private
+// keys as (encryption, signing).
+func (ski *SKI) NewIdentity() (
+	plan.IdentityPublicKey, plan.IdentityPublicKey) {
+	// TODO: I don't like the return signature here. too easy to screw up
+	return ski.keyring.NewIdentity()
+}
+
+// NewCommunityKey generates a new community key, adds it to the keyring,
+// and returns the CommunityKeyID associated with that key.
+func (ski *SKI) NewCommunityKey() plan.CommunityKeyID {
+	return ski.keyring.NewCommunityKey()
+}
+
+// ---------------------------------------------------------
+//
+// Helper functions
+// some of these will want to stay in the SKI, whereas others
+// make more sense to land in the plan.go types. Lots of making
+// up for golang's embarassing type system here
+//
+
+// TODO: we'll want to make this a method on plan.PDIEntrySig
+func newSig(arr []byte) plan.PDIEntrySig {
+	sig := plan.PDIEntrySig{}
+	copy(sig[:], arr[:64])
+	return sig
+}
+
+// TODO: we'll want to make this a method on plan.IdentityPublicKey
+func newPubKey(arr *[32]byte) plan.IdentityPublicKey {
+	k := plan.IdentityPublicKey(*arr)
+	return k
+}
+
+// TODO: we'll want to make this a method on plan.IdentityPublicKey
+func pubKeyToArray(k plan.IdentityPublicKey) *[32]byte {
+	arr := [32]byte(k)
+	return &arr
+}
+
+// TODO: we'll want to make this a method on plan.CommunityKey
+func communityKeyToArray(k plan.CommunityKey) *[32]byte {
+	arr := [32]byte(k)
+	return &arr
+}

--- a/ski/ski_test.go
+++ b/ski/ski_test.go
@@ -1,0 +1,94 @@
+package ski // import "github.com/plan-tools/go-plan/ski"
+
+import (
+	"bytes"
+	"testing"
+
+	plan "github.com/plan-tools/go-plan/plan"
+)
+
+func TestSymmetricEncrypion(t *testing.T) {
+
+	ski, _, _ := setUpSKI(t)
+	keyId := ski.NewCommunityKey()
+	clearIn := []byte("hello, world!")
+
+	encryptOut, err := ski.Encrypt(keyId, clearIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clearOut, err := ski.Decrypt(keyId, encryptOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(clearIn, clearOut) {
+		t.Fatalf("got %v after decryption, expected %v", clearOut, clearIn)
+	}
+}
+
+func TestPublicKeyEncrypion(t *testing.T) {
+
+	senderSki, senderEncryptPubKey, _ := setUpSKI(t)
+	recvSki, recvEncryptPubKey, _ := setUpSKI(t)
+	clearIn := []byte("hello, world!")
+
+	encryptOut, err := senderSki.EncryptFor(senderEncryptPubKey, clearIn, recvEncryptPubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clearOut, err := recvSki.DecryptFrom(
+		recvEncryptPubKey, encryptOut, senderEncryptPubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(clearIn, clearOut) {
+		t.Fatalf("got %v after decryption, expected %v", clearOut, clearIn)
+	}
+}
+
+func TestSigning(t *testing.T) {
+
+	senderSki, _, senderSignPubKey := setUpSKI(t)
+	recvSki, _, _ := setUpSKI(t)
+
+	entry := &plan.PDIEntryCrypt{
+		HeaderCrypt: []byte("encryptedtestheader"),
+		BodyCrypt:   []byte("encryptedtestbody"),
+	}
+	hash := &plan.PDIEntryHash{}
+	entry.ComputeHash(hash)
+
+	sig, err := senderSki.Sign(senderSignPubKey, *hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, ok := recvSki.Verify(senderSignPubKey, *hash, sig)
+	if !ok {
+		t.Fatalf("signature verification failed: %x", verified)
+	}
+}
+
+func TestVouching(t *testing.T) {
+
+	senderSki, senderEncryptPubKey, _ := setUpSKI(t)
+	recvSki, recvEncryptPubKey, _ := setUpSKI(t)
+	keyId := senderSki.NewCommunityKey()
+
+	msg, err := senderSki.Vouch(keyId, senderEncryptPubKey, recvEncryptPubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = recvSki.AcceptVouch(recvEncryptPubKey, msg, senderEncryptPubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// test setup helper
+func setUpSKI(t *testing.T) (
+	*SKI, plan.IdentityPublicKey, plan.IdentityPublicKey,
+) {
+	ski := NewSKI()
+	encryptPubKey, signPubKey := ski.NewIdentity()
+	return ski, encryptPubKey, signPubKey
+}


### PR DESCRIPTION
The `ski` package provides an interface for SKI operations (encryption, decryption, signing, and verification) as well as a simple keyring implementation. This package can be wrapped in a binary that communicates over a socket with the client and/or pnode.

@drew-512 this PR doesn't include changes to the structs in `plan/plan.go` yet (removing the now-unused Nonce field). I also don't have CI wired up yet because there are failing tests in the pnode subpackage that would be out of scope for this PR. I just wanted to land this PR so that we had a starting point for the rest of the work.