### PR TITLE
add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+Thanks for reporting an issue with go-plan!
+
+If you're reporting a problem or think you've found a bug, please be sure to include the following information:
+
+- what is happening and what you expect to see
+- the output of any logs you can share
+
+If you can't provide some of this information because it's private, include what you can and we'll try to assist anyways.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Thanks for contributing to go-plan! Please include with your pull request:
+
+- A description of what you did for the changelog
+- An explanation of why go-plan needs this change
+- How to verify that it works (most PRs need tests!)
+- A link to the GitHub issue that it addresses
+
+If you're contributing a new feature, it's usually better to open an issue to discuss the feature rather than open a pull request unless the feature is trivial.


### PR DESCRIPTION
This PR shamelessly borrows from another project I've worked on, and adds GitHub-specific template files that will pre-populate the text field when someone uses the `New Issue` or `New Pull Request` buttons in the GitHub web UI.

ref https://blog.github.com/2016-02-17-issue-and-pull-request-templates/